### PR TITLE
Updated sample registry client

### DIFF
--- a/api/src/main/java/org/cirdles/mars/api/SampleRegistryClient.java
+++ b/api/src/main/java/org/cirdles/mars/api/SampleRegistryClient.java
@@ -1,12 +1,29 @@
 package org.cirdles.mars.api;
 
+import java.util.List;
+
 /**
- * Created by johnzeringue on 12/10/15.
+ * An interface defining a client for a sample registry.
  */
 public interface SampleRegistryClient {
 
+    /**
+     * Checks this client's authentication unless the registry does not require
+     * authentication.
+     *
+     * @return whether or not this client is authenticated
+     */
     boolean checkAuthentication();
 
-    void register(SampleSource sampleSource);
+    /**
+     * Registers the samples from the given source in this client's registry.
+     * It returns a list of registration strings whose length should match the
+     * length of the list of samples provided by the sample source. If this
+     * registry does not assign registration strings, it should return null.
+     *
+     * @param sampleSource the source of the samples
+     * @return a list of registration strings or null if not provided
+     */
+    List<String> register(SampleSource sampleSource);
 
 }

--- a/sesar/src/main/java/org/cirdles/mars/sesar/SesarClient.java
+++ b/sesar/src/main/java/org/cirdles/mars/sesar/SesarClient.java
@@ -15,6 +15,7 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import java.io.ByteArrayOutputStream;
 import java.io.UnsupportedEncodingException;
+import java.util.List;
 
 import static javax.ws.rs.client.Entity.form;
 import static org.glassfish.jersey.client.ClientProperties.CONNECT_TIMEOUT;
@@ -77,7 +78,7 @@ public class SesarClient implements SampleRegistryClient {
     }
 
     @Override
-    public void register(SampleSource sampleSource) {
+    public List<String> register(SampleSource sampleSource) {
         Samples samples = sampleMapper.translateToSesarSamples(sampleSource);
 
         String samplesXml;
@@ -109,6 +110,8 @@ public class SesarClient implements SampleRegistryClient {
             System.out.println("Success!");
             System.out.println(response.readEntity(String.class));
         }
+
+        return null;
     }
 
 }


### PR DESCRIPTION
Updated the sample registry client interface so that it now returns a
list of registration strings (in this case IGSNs) after registration if
appropriate.